### PR TITLE
Adding standard values and searches to rollups.

### DIFF
--- a/makeFlatTables.v3.R
+++ b/makeFlatTables.v3.R
@@ -68,11 +68,18 @@ getStandardizedDimensions <- function(dims) {
     isstdprofile <- isStandardProfile(dims$vendor, dims$name)
     stdchannel <- getStandardChannel(dims$channel)
     stdos <- getStandardOS(dims$os)
-    ismozdistrib <- isMozillaDistrib(dims$distribution)
-    distribpartner <-getPartnerName(dims$distribution)
+    ## Identifier for the distribution group.
+    ## "mozilla" for standard Moz distributions,
+    ## <partnerID> for partner builds,
+    ## otherwise "other".
+    distribtype <- if(isMozillaDistrib(dims$distribution)) { 
+        "mozilla" 
+    } else { 
+        getPartnerName(dims$distribution) 
+    }
     
     list(isstdprofile=isstdprofile, stdchannel=stdchannel, stdos=stdos,
-        ismozdistrib=ismozdistrib, distribpartner=distribpartner)
+        distribtype=distribtype)
 }
 
 ## Is the record considered a standard Firefox profile
@@ -112,11 +119,11 @@ isMozillaDistrib <- function(distrib) {
 }
 
 ## If the distribution is considered a partner build, find the partner name.
-## Otherwise, return "none".
+## Otherwise, return "other".
 ## partner.list is a lookup table mapping distribution IDs
 ## to corresponding partner name.
 getPartnerName <- function(distrib) {
-    if(!(distrib %in% names(partner.list))) return("none")
+    if(!(distrib %in% names(partner.list))) return("other")
     partner.list[[distrib]]
 }
 

--- a/makeFlatTables.v3.R
+++ b/makeFlatTables.v3.R
@@ -52,7 +52,7 @@ getDimensions <- function(b){
             WNVer(b$data$last$org.mozilla.sysinfo.sysinfo$version)
         }else "none"
     })
-    distribution <- isn(r$data$last$org.mozilla.appInfo.appinfo$distributionID,
+    distribution <- isn(b$data$last$org.mozilla.appInfo.appinfo$distributionID,
         "missing")
     locale <- isn(b$data$last$org.mozilla.appInfo.appinfo$locale, "missing")
     geo <- isn(b$geo)
@@ -130,10 +130,9 @@ getPartnerName <- function(distrib) {
     if(distrib %in% names(partner.list.current)) 
         return(partner.list.current[[distrib]])
     if(distrib %in% names(partner.list.expired))
-        return(sprintf("%s|expired", partner.list.expired[[distrib]])
+        return(sprintf("%s|expired", partner.list.expired[[distrib]]))
     "other"
 }
-
 
 getProfileCreationDate <- function(b){
     profileCrDate <- strftime(as.Date(
@@ -305,7 +304,7 @@ searchNamesOfficialAndPartner <- function(distribtype, pluginprefix = NULL,
     
     if(length(partnername) > 0 && distribtype %in% partnername) {
         searchnames <- append(searchnames, 
-            sprintf("other-%s", partner.plugins[[distribtype]])
+            sprintf("other-%s", partner.plugins[[distribtype]]))
     }
     searchnames
 }
@@ -410,7 +409,7 @@ summaries <- function(a,b){
     bdim              <- getDimensions(b)
     bdim              <- append(bdim, getStandardizedDimensions(bdim))
     bdim$snapshot     <- PARAM$whichDate
-    bdim$granularity  <- PARAM$granularity
+    bdim$granularity  <- PARAM$granularity  
     profileCrDate     <- getProfileCreationDate(b)
     if(is.null(profileCrDate)) return()
     lapply(PARAM$listOfTimeChunks,function(timeChunk){


### PR DESCRIPTION
The main changes here are to add standard values for dimensions and logic for search counts. Specific changes are as follows:
- Added distribution to dimensions
- Added a set of "standardized" dimensions to include standard channel, standard distribution identifier (moz/partner/other), standard OS. These do not increase the dimesionality of bdims and are intended to simplify querying on common standard dimension values.
- Added preprocessing for session activity to exclude weird values up front.
- Added preprocessing for search counts to parse out search provider names.
- Added logic to count searches for specific search providers. These functions reference lookup tables which are not included as of yet.
- Minor formatting
