### PR TITLE
Fix for search plugin names

### DIFF
--- a/makeFlatTables.v3.R
+++ b/makeFlatTables.v3.R
@@ -275,7 +275,7 @@ searchNamesOfficialAndPartner <- function(distribtype, pluginprefix = NULL,
         official.plugins 
     } else {
         patterns <- sprintf("^%s", pluginprefix)
-        unlist(lapply(patterns, grepl, official.plugins))
+        unlist(lapply(patterns, grep, official.plugins, value = TRUE))
     }
     
     if(length(partnername) > 0 && distribtype %in% partnername) {


### PR DESCRIPTION
A bug in the function to lookup the search plugin names was returning booleans instead of values. Unfortunately this will affect the final output.
